### PR TITLE
Fix failing tests and update tools

### DIFF
--- a/testbench/ahb_lsu_dma_bridge.sv
+++ b/testbench/ahb_lsu_dma_bridge.sv
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Antmicro <www.antmicro.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Connects LSU master (AHB) to external lmem (AHB slave) and DMA slave (AHB)
+module ahb_lsu_dma_bridge
+#(
+  TAG = 1,
+  `include "eh2_param.vh"
+)
+(
+    input                   clk,
+    input                   reset_l,
+
+    // AHB master interface (LSU)
+    input logic [31:0]      m_ahb_haddr,     // ahb bus address
+    input logic [2:0]       m_ahb_hburst,    // tied to 0
+    input logic             m_ahb_hmastlock, // tied to 0
+    input logic [3:0]       m_ahb_hprot,     // tied to 4'b0011
+    input logic [2:0]       m_ahb_hsize,     // size of bus transaction (possible values 0,1,2,3)
+    input logic [1:0]       m_ahb_htrans,    // Transaction type (possible values 0,2 only right now)
+    input logic             m_ahb_hwrite,    // ahb bus write
+    input logic [63:0]      m_ahb_hwdata,    // ahb bus write data
+    input logic             m_ahb_hsel,      // this slave was selected
+    input logic             m_ahb_hreadyin,  // previous hready was accepted or not
+    output logic [63:0]     m_ahb_hrdata,    // ahb bus read data
+    output logic            m_ahb_hreadyout, // slave ready to accept transaction
+    output logic            m_ahb_hresp,     // slave response (high indicates erro)
+
+    // AHB slave interface (lmem)
+    output logic            s0_ahb_hsel,        // ahb bus slave select
+    output logic [31:0]     s0_ahb_haddr,       // ahb bus address
+    output logic [2:0]      s0_ahb_hburst,      // tied to 0
+    output logic            s0_ahb_hmastlock,   // tied to 0
+    output logic [3:0]      s0_ahb_hprot,       // [3:1] are tied to 3'b001
+    output logic [2:0]      s0_ahb_hsize,       // size of bus transaction (possible values 0,1,2,3)
+    output logic [1:0]      s0_ahb_htrans,      // Transaction type (possible values 0,2 only right now)
+    output logic            s0_ahb_hwrite,      // ahb bus write
+    output logic [63:0]     s0_ahb_hwdata,      // ahb bus write data
+    input logic  [63:0]     s0_ahb_hrdata,      // ahb bus read data
+    input logic             s0_ahb_hready,      // connect to veer's dma_hreadyout
+    input logic             s0_ahb_hresp,       // slave response (high indicates erro)
+
+    // AHB slave interface (dma)
+    output logic            s1_ahb_hsel,        // ahb bus slave select
+    output logic [31:0]     s1_ahb_haddr,       // ahb bus address
+    output logic [2:0]      s1_ahb_hburst,      // tied to 0
+    output logic            s1_ahb_hmastlock,   // tied to 0
+    output logic [3:0]      s1_ahb_hprot,       // [3:1] are tied to 3'b001
+    output logic [2:0]      s1_ahb_hsize,       // size of bus transaction (possible values 0,1,2,3)
+    output logic [1:0]      s1_ahb_htrans,      // Transaction type (possible values 0,2 only right now)
+    output logic            s1_ahb_hwrite,      // ahb bus write
+    output logic [63:0]     s1_ahb_hwdata,      // ahb bus write data
+    input logic  [63:0]     s1_ahb_hrdata,      // ahb bus read data
+    input logic             s1_ahb_hready,      // connect to veer's dma_hreadyout
+    input logic             s1_ahb_hresp        // slave response (high indicates erro)
+);
+
+parameter ICCM_BASE = `RV_ICCM_BITS; // in LSBs
+bit[31:0] iccm_real_base_addr = `RV_ICCM_SADR ;
+
+wire bus_active;
+wire slave_select;
+
+reg slave_select_dly;
+
+assign bus_active = m_ahb_htrans inside {2'b10, 2'b11};
+assign slave_select = m_ahb_haddr[31:ICCM_BASE] == iccm_real_base_addr[31:ICCM_BASE];
+
+assign s0_ahb_hsel = bus_active & ~slave_select;
+assign s0_ahb_haddr = m_ahb_haddr;
+assign s0_ahb_hburst = m_ahb_hburst;
+assign s0_ahb_hmastlock = m_ahb_hmastlock;
+assign s0_ahb_hprot  = m_ahb_hprot;
+assign s0_ahb_hsize  = m_ahb_hsize;
+assign s0_ahb_htrans = m_ahb_htrans;
+assign s0_ahb_hwrite = m_ahb_hwrite;
+assign s0_ahb_hwdata = m_ahb_hwdata;
+
+assign s1_ahb_hsel = bus_active & slave_select;
+assign s1_ahb_haddr = m_ahb_haddr;
+assign s1_ahb_hburst = m_ahb_hburst;
+assign s1_ahb_hmastlock = m_ahb_hmastlock;
+assign s1_ahb_hprot  = m_ahb_hprot;
+assign s1_ahb_hsize  = m_ahb_hsize;
+assign s1_ahb_htrans = m_ahb_htrans;
+assign s1_ahb_hwrite = m_ahb_hwrite;
+assign s1_ahb_hwdata = m_ahb_hwdata;
+
+assign m_ahb_hreadyout = &{s0_ahb_hready, s1_ahb_hready};
+assign m_ahb_hrdata = slave_select_dly ? s1_ahb_hrdata : s0_ahb_hrdata;
+assign m_ahb_hresp  = slave_select_dly ? s1_ahb_hresp : s0_ahb_hresp;
+
+always_ff @(posedge clk or negedge reset_l) begin
+  if(~reset_l) slave_select_dly <= 1'b0;
+  else slave_select_dly <= slave_select;
+end
+
+endmodule

--- a/testbench/ahb_sif.sv
+++ b/testbench/ahb_sif.sv
@@ -55,7 +55,7 @@ wire [7:0] strb =  HSIZE == 3'b000 ? 8'h1 << HADDR[2:0] :
                    HSIZE == 3'b010 ? 8'hf << {HADDR[2],2'b0} : 8'hff;
 
 
-wire mailbox_write = write && laddr==MAILBOX_ADDR;
+wire mailbox_write = write && HSEL && HREADY && laddr==MAILBOX_ADDR;
 
 
 initial begin
@@ -226,4 +226,3 @@ assign rlast   = 1'b1;
 
 endmodule
 `endif
-

--- a/testbench/asm/hello_world_dccm.ld
+++ b/testbench/asm/hello_world_dccm.ld
@@ -8,9 +8,10 @@ SECTIONS {
   . = 0xd0580000;
   .data.io .  : { *(.data.io) }
   . = 0xf0040000;
-  .data  :  { *(.*data) *(.rodata*) *(.sbss) }
+  .data  :  { *(.*data) *(.rodata*) *(.srodata*) *(.sbss*) }
   .bss : { *(.bss) }
   STACK = ALIGN(16) + 0x2000;
   . = 0xfffffff8;
   .data.ctl : { LONG(0xf0040000); LONG(STACK) }
+  /DISCARD/ : { *(.eh_frame*) }
 }

--- a/testbench/flist
+++ b/testbench/flist
@@ -48,6 +48,7 @@ $RV_ROOT/design/lib/eh2_lib.sv
 -v $RV_ROOT/design/lib/mem_lib.sv
 -y $RV_ROOT/design/lib
 $RV_ROOT/testbench/axi_lsu_dma_bridge.sv
+$RV_ROOT/testbench/ahb_lsu_dma_bridge.sv
 $RV_ROOT/testbench/remote_bitbang.cc
 $RV_ROOT/testbench/SimJTAG.cc
 $RV_ROOT/testbench/SimJTAG.v

--- a/testbench/flist.riviera
+++ b/testbench/flist.riviera
@@ -48,4 +48,5 @@ $RV_ROOT/design/lib/eh2_lib.sv
 -v $RV_ROOT/design/lib/mem_lib.sv
 -y $RV_ROOT/design/lib
 $RV_ROOT/testbench/axi_lsu_dma_bridge.sv
+$RV_ROOT/testbench/ahb_lsu_dma_bridge.sv
 $RV_ROOT/testbench/SimJTAG.v

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -317,10 +317,15 @@ module tb_top;
 
     always @(negedge core_clk) begin
         cycleCnt <= cycleCnt+1;
-        // Test timeout monitor
+        // Timeout monitor
         if(cycleCnt == MAX_CYCLES) begin
-            $display ("Hit max cycle count (%0d) .. stopping",cycleCnt);
-            $finish;
+            $display ("Hit max cycle count (%0d) .. stopping", cycleCnt);
+            $display("TEST_FAILED");
+            `ifdef TB_SILENT_FAIL
+                $finish;
+            `else
+                $fatal;
+            `endif // TB_SILENT_FAIL
         end
         // console Monitor
         if( mailbox_data_val & mailbox_write) begin
@@ -338,7 +343,11 @@ module tb_top;
         end
         else if(mailbox_write && WriteData[7:0] == 8'h1) begin
             $display("TEST_FAILED");
-            $finish;
+            `ifdef TB_SILENT_FAIL
+                $finish;
+            `else
+                $fatal;
+            `endif // TB_SILENT_FAIL
         end
     end
 
@@ -1025,7 +1034,11 @@ if ( (saddr < `RV_ICCM_SADR) || (saddr > `RV_ICCM_EADR)) return;
     $display("********************************************************");
     $display("ICCM preload: there is no ICCM in VeeR, terminating !!!");
     $display("********************************************************");
-    $finish;
+    `ifdef TB_SILENT_FAIL
+        $finish;
+    `else
+        $fatal;
+    `endif // TB_SILENT_FAIL
 `endif
 addr += 4;
 eaddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
@@ -1059,7 +1072,11 @@ if (saddr < `RV_DCCM_SADR || saddr > `RV_DCCM_EADR) return;
     $display("********************************************************");
     $display("DCCM preload: there is no DCCM in VeeR, terminating !!!");
     $display("********************************************************");
-    $finish;
+    `ifdef TB_SILENT_FAIL
+        $finish;
+    `else
+        $fatal;
+    `endif // TB_SILENT_FAIL
 `endif
 addr += 4;
 eaddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -68,10 +68,32 @@ module tb_top;
     logic                       o_cpu_run_ack;
 
     logic                       mailbox_write;
-    logic        [63:0]         dma_hrdata;
-    logic        [63:0]         dma_hwdata;
+
+    logic [63:0]                lmem_hrdata;
+    logic [63:0]                lmem_hwdata;
+    logic                       lmem_hready;
+    logic                       lmem_hresp;
+    logic [31:0]                lmem_haddr;
+    logic [2:0]                 lmem_hburst;
+    logic                       lmem_hmastlock;
+    logic [3:0]                 lmem_hprot;
+    logic [2:0]                 lmem_hsize;
+    logic [1:0]                 lmem_htrans;
+    logic                       lmem_hwrite;
+    logic                       lmem_hsel;
+
+    logic [63:0]                dma_hrdata;
+    logic [63:0]                dma_hwdata;
     logic                       dma_hready;
     logic                       dma_hresp;
+    logic [31:0]                dma_haddr;
+    logic [2:0]                 dma_hburst;
+    logic                       dma_hmastlock;
+    logic [3:0]                 dma_hprot;
+    logic [2:0]                 dma_hsize;
+    logic [1:0]                 dma_htrans;
+    logic                       dma_hwrite;
+    logic                       dma_hsel;
 
     logic                       mpc_debug_halt_req;
     logic                       mpc_debug_run_req;
@@ -83,7 +105,6 @@ module tb_top;
     bit        [31:0]           cycleCnt;
     logic                       mailbox_data_val;
 
-    wire                        dma_hready_out;
     int                         commit_count[2];
 
     logic [1:0]                 wb_valid;
@@ -510,20 +531,20 @@ eh2_veer_wrapper rvtop (
     //---------------------------------------------------------------
     // DMA Slave
     //---------------------------------------------------------------
-    .dma_haddr              ( '0 ),
-    .dma_hburst             ( '0 ),
-    .dma_hmastlock          ( '0 ),
-    .dma_hprot              ( '0 ),
-    .dma_hsize              ( '0 ),
-    .dma_htrans             ( '0 ),
-    .dma_hwrite             ( '0 ),
-    .dma_hwdata             ( '0 ),
+    .dma_haddr              ( dma_haddr      ),
+    .dma_hburst             ( dma_hburst     ),
+    .dma_hmastlock          ( dma_hmastlock  ),
+    .dma_hprot              ( dma_hprot      ),
+    .dma_hsize              ( dma_hsize      ),
+    .dma_htrans             ( dma_htrans     ),
+    .dma_hwrite             ( dma_hwrite     ),
+    .dma_hwdata             ( dma_hwdata     ),
 
-    .dma_hrdata             (),
-    .dma_hresp              (),
-    .dma_hsel               ( 1'b1 ),
-    .dma_hreadyin           ( 1'b1 ),
-    .dma_hreadyout          (),
+    .dma_hrdata             ( dma_hrdata     ),
+    .dma_hresp              ( dma_hresp      ),
+    .dma_hsel               ( dma_hsel       ),
+    .dma_hreadyin           ( dma_hready     ),
+    .dma_hreadyout          ( dma_hready     ),
 `endif
 `ifdef RV_BUILD_AXI4
 //-------------------------- LSU AXI signals--------------------------
@@ -843,22 +864,67 @@ ahb_sif imem (
 
 ahb_sif lmem (
      // Inputs
-     .HWDATA(lsu_hwdata),
+     .HWDATA(lmem_hwdata),
      .HCLK(core_clk),
-     .HSEL(1'b1),
-     .HPROT(lsu_hprot),
-     .HWRITE(lsu_hwrite),
-     .HTRANS(lsu_htrans),
-     .HSIZE(lsu_hsize),
-     .HREADY(lsu_hready),
+     .HSEL(lmem_hsel),
+     .HPROT(lmem_hprot),
+     .HWRITE(lmem_hwrite),
+     .HTRANS(lmem_htrans),
+     .HSIZE(lmem_hsize),
+     .HREADY(lmem_hready),
      .HRESETn(rst_l),
-     .HADDR(lsu_haddr),
-     .HBURST(lsu_hburst),
+     .HADDR(lmem_haddr),
+     .HBURST(lmem_hburst),
 
      // Outputs
-     .HREADYOUT(lsu_hready),
-     .HRESP(lsu_hresp),
-     .HRDATA(lsu_hrdata)
+     .HREADYOUT(lmem_hready),
+     .HRESP(lmem_hresp),
+     .HRDATA(lmem_hrdata)
+);
+
+ahb_lsu_dma_bridge bridge (
+    .clk(core_clk),
+    .reset_l(rst_l),
+
+    .m_ahb_haddr(lsu_haddr),
+    .m_ahb_hburst(lsu_hburst),
+    .m_ahb_hmastlock(),
+    .m_ahb_hprot(lsu_hprot),
+    .m_ahb_hsize(lsu_hsize),
+    .m_ahb_htrans(lsu_htrans),
+    .m_ahb_hwrite(lsu_hwrite),
+    .m_ahb_hwdata(lsu_hwdata),
+    .m_ahb_hsel(1'b1),
+    .m_ahb_hreadyin(lsu_hready),
+    .m_ahb_hrdata(lsu_hrdata),
+    .m_ahb_hreadyout(lsu_hready),
+    .m_ahb_hresp(lsu_hresp),
+
+    .s0_ahb_hsel(lmem_hsel),
+    .s0_ahb_haddr(lmem_haddr),
+    .s0_ahb_hburst(lmem_hburst),
+    .s0_ahb_hmastlock(lmem_hmastlock),
+    .s0_ahb_hprot(lmem_hprot),
+    .s0_ahb_hsize(lmem_hsize),
+    .s0_ahb_htrans(lmem_htrans),
+    .s0_ahb_hwrite(lmem_hwrite),
+    .s0_ahb_hwdata(lmem_hwdata),
+    .s0_ahb_hrdata(lmem_hrdata),
+    .s0_ahb_hready(lmem_hready),
+    .s0_ahb_hresp(lmem_hresp),
+
+    .s1_ahb_hsel(dma_hsel),
+    .s1_ahb_haddr(dma_haddr),
+    .s1_ahb_hburst(dma_hburst),
+    .s1_ahb_hmastlock(dma_hmastlock),
+    .s1_ahb_hprot(dma_hprot),
+    .s1_ahb_hsize(dma_hsize),
+    .s1_ahb_htrans(dma_htrans),
+    .s1_ahb_hwrite(dma_hwrite),
+    .s1_ahb_hwdata(dma_hwdata),
+    .s1_ahb_hrdata(dma_hrdata),
+    .s1_ahb_hready(dma_hready),
+    .s1_ahb_hresp(dma_hresp)
 );
 
 `endif

--- a/testbench/tests/dhry/dhry.h
+++ b/testbench/tests/dhry/dhry.h
@@ -433,5 +433,3 @@ typedef struct record
                   } var_3;
           } variant;
       } Rec_Type, *Rec_Pointer;
-
-

--- a/testbench/tests/dhry/dhry_1.c
+++ b/testbench/tests/dhry/dhry_1.c
@@ -313,9 +313,8 @@ main ()
   {
 #ifdef VEER
     printf ("Run time = %d clocks for %d Dhrystones\n", User_Time, Number_Of_Runs );
-    printf ("Dhrystones per Second per MHz: %6.2f\n", 1000000.0*Number_Of_Runs/User_Time);
-    printf ("Dhrystone score per Second per MHz: %2.2f\n", 1000000.0/1757.0*Number_Of_Runs/User_Time);
-    printf ("To get CPU absolute score multiply previous number by CPU fequency in MHz.\n");
+    printf ("Dhrystones per Second per MHz: ");
+    printf ("%d.%02d", 1000000*Number_Of_Runs/User_Time,(100000000*Number_Of_Runs/User_Time) % 100);
 #else
 #ifdef TIME
     Microseconds = (float) User_Time * Mic_secs_Per_Second
@@ -337,6 +336,7 @@ main ()
     printf ("\n");
   }
 
+  return 0;
 }
 
 

--- a/testbench/tests/dhry/dhry_1.c
+++ b/testbench/tests/dhry/dhry_1.c
@@ -449,5 +449,3 @@ register int    l;
         while (l--) *d++ = *s++;
 }
 #endif
-
-

--- a/testbench/tests/dhry/dhry_2.c
+++ b/testbench/tests/dhry/dhry_2.c
@@ -211,4 +211,3 @@ Enumeration Enum_Par_Val;
   else /* not executed */
     return (false);
 } /* Func_3 */
-

--- a/testbench/tests/dhry_mt/dhry_1.c
+++ b/testbench/tests/dhry_mt/dhry_1.c
@@ -484,5 +484,3 @@ register int    l;
         while (l--) *d++ = *s++;
 }
 #endif
-
-

--- a/testbench/tests/dhry_mt/dhry_1.c
+++ b/testbench/tests/dhry_mt/dhry_1.c
@@ -324,10 +324,13 @@ if(hartid == 0) {
   {
 #ifdef VEER
     Number_Of_Runs *=2; // 2harts
-    printf ("Run time = %llu clocks for %d Dhrystones\n", globals->User_Time, Number_Of_Runs );
-    printf ("Dhrystones per Second per MHz: %6.2f\n", 1000000.0*Number_Of_Runs/globals->User_Time);
-    printf ("Dhrystone score per Second per MHz: %2.2f\n", 1000000.0/1757.0*Number_Of_Runs/globals->User_Time);
-    printf ("To get CPU absolute score multiply previous number by CPU fequency in MHz.\n");
+    uint64_t dhrystones_per_mhz_x100 =
+      (100000000ULL * (uint64_t) Number_Of_Runs) / globals->User_Time;
+    printf ("Run time = %llu clocks for %d Dhrystones\n", globals->User_Time, Number_Of_Runs);
+    printf ("Dhrystones per Second per MHz: ");
+    printf ("%d.%02d", (int) (dhrystones_per_mhz_x100 / 100),
+            (dhrystones_per_mhz_x100 % 100));
+    printf ("\nTo get CPU absolute score multiply previous number by CPU frequency in MHz.\n");
 #else
 #ifdef TIME
     Microseconds = (float) User_Time * Mic_secs_Per_Second
@@ -347,6 +350,7 @@ if(hartid == 0) {
 #endif
   }
 }
+return 0;
 }
 
 

--- a/testbench/tests/dhry_mt/dhry_1.c
+++ b/testbench/tests/dhry_mt/dhry_1.c
@@ -136,6 +136,7 @@ driver (struct Globals* globals)
   REG   int             Number_Of_Runs;
 
   unsigned hartid = getHartId();
+  Number_Of_Runs = 1000;
   /* Initializations */
 
   Rec_Type rec0;
@@ -169,11 +170,6 @@ if(hartid == 0) {
     printf ("Program compiled without 'register' attribute\n");
   }
 //  printf ("Please give the number of runs through the benchmark: ");
-  {
-    int n = 1000;
-    // scanf ("%d", &n);
-    Number_Of_Runs = n;
-  }
   printf ("Execution starts, %d runs through Dhrystone\n", Number_Of_Runs);
 }
   /***************/

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -17,7 +17,7 @@
 # need to be removed for opensource
 CONF_PARAMS = -set=build_axi4
 
-TEST_CFLAGS = -g -O3 -funroll-all-loops 
+TEST_CFLAGS = -g -O3 -funroll-all-loops
 
 ABI = -mabi=ilp32 -march=rv32imac_zicsr_zifencei
 
@@ -86,7 +86,7 @@ defines += ${RV_ROOT}/design/include/eh2_def.sv
 defines += $(BUILD_DIR)/eh2_pdef.vh
 includes = -I${BUILD_DIR}
 
-# CFLAGS for verilator generated Makefiles.
+# CFLAGS for verilator generated Makefiles
 CFLAGS += "-std=c++14"
 
 # Optimization for better performance; alternative is nothing for


### PR DESCRIPTION
This PR introduces fixes for failing tests and update tools versions:
* Adds an AHB bridge to properly handle transaction routed from EH2 to system bus
* Makes linker script more strict to mitigate overwriting sections
* Removes floating point operations from benchmark tests since EH2 doesn't support them
* Throws fatal error on test fail instead of introducing false positive passes
* Adjusts build flow and software to work with more recent toolchain and Verilator versions
* Fixes incorrect mailbox write detection