### PR TITLE
Fix tests and errata docs layout

### DIFF
--- a/docs/source/errata.md
+++ b/docs/source/errata.md
@@ -1,36 +1,19 @@
-(chap-errata)=
-# VeeR EH2 Errata
+# Errata
 
 ## Back-to-back Write Transactions Not Supported on AHB-Lite Bus
 
-### Description
-
-The AHB-Lite bus interface for LSU is not optimized for write performance.
-Each aligned store is issued to the bus as a single write transaction followed by an idle cycle.
-Each unaligned store is issued to the bus as multiple backto-back byte write transactions followed by an idle cycle.
-These idle cycles limit the achievable bus utilization for writes.
-
-### Symptoms
-
-Potential performance impact for writes with AHB-Lite bus.
-
-### Workaround
-
-None.
+* **Description:** The AHB-Lite bus interface for LSU is not optimized for write performance.
+  Each aligned store is issued to the bus as a single write transaction followed by an idle cycle.
+  Each unaligned store is issued to the bus as multiple backto-back byte write transactions followed by an idle cycle.
+  These idle cycles limit the achievable bus utilization for writes.
+* **Symptoms:** Potential performance impact for writes with AHB-Lite bus.
+* **Workaround:** None.
 
 ## Debug Abstract Command Register May Return Non-Zero Value on Read
 
-### Description
-
-The RISC-V External Debug specification specifies the abstract command (`command`) register as write-only (see Section 3.14.7 in [[3]](intro.md#ref-3)).
-However, the VeeR EH2 implementation supports write as well as read operations to this register.
-This may help a debugger's feature discovery process, but is not fully compliant with the RISC-V External Debug specification.
-Because the expected return value for reading this register is always zero, it is unlikely that a debugger expecting a zero value would attempt to read it.
-
-### Symptoms
-
-Reading the debug abstract command (`command`) register may return a non-zero value.
-
-### Workaround
-
-A debugger should avoid reading the abstract command register if it cannot handle non-zero data.
+* **Description:** The RISC-V External Debug specification specifies the abstract command (`command`) register as write-only (see Section 3.14.7 in [[3]](intro.md#ref-3)).
+  However, the VeeR EH2 implementation supports write as well as read operations to this register.
+  This may help a debugger's feature discovery process, but is not fully compliant with the RISC-V External Debug specification.
+  Because the expected return value for reading this register is always zero, it is unlikely that a debugger expecting a zero value would attempt to read it.
+* **Symptoms:** Reading the debug abstract command (`command`) register may return a non-zero value.
+* **Workaround:** A debugger should avoid reading the abstract command register if it cannot handle non-zero data.

--- a/docs/source/tests.md
+++ b/docs/source/tests.md
@@ -1,74 +1,42 @@
-(chap-tests)=
-# VeeR EH2 Compliance Test Suite Failures
+# Compliance Test Suite Failures
 
-## I-MISALIGN\_LDST-01
+## *I-MISALIGN\_LDST-01*
 
-## Test Location:
+* **Test Location:** [https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN\_LDST-01.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN\_LDST-01.S)
+* **Reason for Failure:** The VeeR EH2 core supports unaligned accesses to memory addresses which are not marked as having side effects (i.e., to idempotent memory).
+  Load and store accesses to non-idempotent memory addresses take misalignment exceptions.
+  :::{note}
+  This is a known issue with the test suite ([https://github.com/riscv/riscv-compliance/issues/22](https://github.com/riscv/riscv-compliance/issues/22)) and is expected to eventually be fixed.
+  :::
+* **Workaround:** Configure the address range used by this test to 'non-idempotent' in the `mrac` register.
 
-[https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN\_LDST-01.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN\_LDST-01.S)
+## *I-MISALIGN\_JMP-01*
 
-## Reason for Failure:
+* **Test Location:** [https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN\_JMP-01.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN\_JMP-01.S)
+* **Reason for Failure:** The VeeR EH2 core supports the standard 'C' 16-bit compressed instruction extension.
+  Compressed instruction execution cannot be turned off.
+  Therefore, branch and jump instructions to 16-bit aligned memory addresses do not trigger misalignment exceptions.
+  :::{note}
+  This is a known issue with the test suite ([https://github.com/riscv/riscv-compliance/issues/16](https://github.com/riscv/riscv-compliance/issues/16)) and is expected to eventually be fixed.
+  :::
+* **Workaround:** None.
 
-The VeeR EH2 core supports unaligned accesses to memory addresses which are not marked as having side effects (i.e., to idempotent memory).
-Load and store accesses to non-idempotent memory addresses take misalignment exceptions.
+## *I-FENCE.I-01* and *fence\_i*
 
-(Note that this is a known issue with the test suite ([https://github.com/riscv/riscv-compliance/issues/22](https://github.com/riscv/riscv-compliance/issues/22)) and is expected to eventually be fixed.)
+* **Test Location:**
+  * [https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32Zifencei/src/I-FENCE.I-01.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32Zifencei/src/I-FENCE.I-01.S)
+  * [https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32ui/src/fence\_i.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32ui/src/fence\_i.S)
+* **Reason for Failure:** The VeeR EH2 core implements separate instruction and data buses to the system interconnect (i.e., Harvard architecture).
+  The latencies to memory through the system interconnect may be different for the two interfaces and the order is therefore not guaranteed.
+* **Workaround:** Configuring the address range used by this test to 'non-idempotent' in the `mrac` register forces the core to wait for a write response before fetching the updated line.
+  Alternatively, the system interconnect could provide ordering guarantees between requests sent to the instruction fetch and load/store bus interfaces (e.g., matching latencies through the interconnect).
 
-## Workaround:
+## *Breakpoint*
 
-Configure the address range used by this test to 'non-idempotent' in the `mrac` register.
-
-## I-MISALIGN\_JMP-01
-
-## Test Location:
-
-[https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN\_JMP-01.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN\_JMP-01.S)
-
-## Reason for Failure:
-
-The VeeR EH2 core supports the standard 'C' 16-bit compressed instruction extension.
-Compressed instruction execution cannot be turned off.
-Therefore, branch and jump instructions to 16-bit aligned memory addresses do not trigger misalignment exceptions.
-
-(Note that this is a known issue with the test suite ([https://github.com/riscv/riscv-compliance/issues/16](https://github.com/riscv/riscv-compliance/issues/16)) and is expected to eventually be fixed.)
-
-## Workaround:
-
-None.
-
-## I-FENCE.I-01 and fence\_i
-
-## Test Location:
-
-[https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32Zifencei/src/I-FENCE.I-01.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32Zifencei/src/I-FENCE.I-01.S)
-
-and
-
-[https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32ui/src/fence\_i.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32ui/src/fence\_i.S)
-
-## Reason for Failure:
-
-The VeeR EH2 core implements separate instruction and data buses to the system interconnect (i.e., Harvard architecture).
-The latencies to memory through the system interconnect may be different for the two interfaces and the order is therefore not guaranteed.
-
-## Workaround:
-
-Configuring the address range used by this test to 'non-idempotent' in the `mrac` register forces the core to wait for a write response before fetching the updated line.
-Alternatively, the system interconnect could provide ordering guarantees between requests sent to the instruction fetch and load/store bus interfaces (e.g., matching latencies through the interconnect).
-
-## breakpoint
-
-## Test Location:
-
-[https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32mi/src/breakpoint.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32mi/src/breakpoint.S)
-
-## Reason for Failure:
-
-The VeeR EH2 core disables breakpoints when the *mie* bit in the standard `mstatus` register is cleared.
-
-(Note that this behavior is compliant with the RISC-V External Debug Support specification, Version 0.13.2.
-See Section 6.1, 'Native M-Mode Triggers' in [[3]](intro.md#ref-3) for more details.)
-
-## Workaround:
-
-None.
+* **Test Location:** [https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32mi/src/breakpoint.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32mi/src/breakpoint.S)
+* **Reason for Failure:** The VeeR EH2 core disables breakpoints when the *mie* bit in the standard `mstatus` register is cleared.
+  :::{note}
+  This behavior is compliant with the RISC-V External Debug Support specification, Version 0.13.2.
+  See Section 6.1, 'Native M-Mode Triggers' in [[3]](intro.md#ref-3) for more details.
+  :::
+* **Workaround:** None.


### PR DESCRIPTION
The layout in "VeeR EH2 Compliance Test Suite Failures" and "VeeR EH2 Errata" chapters is not quite right. This PR fixes that and removes redundant `VeeR EH2` from their names.